### PR TITLE
Bump compiler builtins

### DIFF
--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -92,7 +92,7 @@ pub fn resolve_std<'cfg>(
         None,
         SourceId::for_git(
             &("https://github.com/solana-labs/compiler-builtins".parse()).unwrap(),
-            GitReference::Tag("sbf-tools-v1.31".to_string()),
+            GitReference::Tag("sbf-tools-v1.30".to_string()),
         )?,
     )?);
     let crates_io_url = crate::sources::CRATES_IO_INDEX.parse().unwrap();

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -92,7 +92,7 @@ pub fn resolve_std<'cfg>(
         None,
         SourceId::for_git(
             &("https://github.com/solana-labs/compiler-builtins".parse()).unwrap(),
-            GitReference::Tag("bpf-tools-v1.27".to_string()),
+            GitReference::Tag("sbf-tools-v1.31".to_string()),
         )?,
     )?);
     let crates_io_url = crate::sources::CRATES_IO_INDEX.parse().unwrap();


### PR DESCRIPTION
The version 1.27 of `compiler_builtins` excludes some functions for `sbf` like `__multi3 `(https://github.com/solana-labs/compiler-builtins/blob/bpf-tools-v1.27/src/int/mul.rs). This leads to `Unresolved symbol (__multi3)` in `cargo-build-sbf`  when building with flags `-Z build-std` (rebuilding the standard library from scratch).  

Bumping `compiler_builtins` here will fix this in future releases.