### PR TITLE
[SOL] build-std: pull in our compiler-builtins

### DIFF
--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -6,7 +6,7 @@ use crate::core::compiler::{CompileKind, CompileMode, RustcTargetData, Unit};
 use crate::core::profiles::{Profiles, UnitFor};
 use crate::core::resolver::features::{CliFeatures, FeaturesFor, ResolvedFeatures};
 use crate::core::resolver::HasDevUnits;
-use crate::core::{Dependency, PackageId, PackageSet, Resolve, SourceId, Workspace};
+use crate::core::{Dependency, GitReference, PackageId, PackageSet, Resolve, SourceId, Workspace};
 use crate::ops::{self, Packages};
 use crate::util::errors::CargoResult;
 use crate::Config;
@@ -79,7 +79,7 @@ pub fn resolve_std<'cfg>(
         "rustc-std-workspace-alloc",
         "rustc-std-workspace-std",
     ];
-    let patches = to_patch
+    let mut patches = to_patch
         .iter()
         .map(|&name| {
             let source_path = SourceId::for_path(&src_path.join("library").join(name))?;
@@ -87,6 +87,14 @@ pub fn resolve_std<'cfg>(
             Ok(dep)
         })
         .collect::<CargoResult<Vec<_>>>()?;
+    patches.push(Dependency::parse(
+        "compiler_builtins",
+        None,
+        SourceId::for_git(
+            &("https://github.com/solana-labs/compiler-builtins".parse()).unwrap(),
+            GitReference::Tag("solana-tools-v1.36".to_string()),
+        )?,
+    )?);
     let crates_io_url = crate::sources::CRATES_IO_INDEX.parse().unwrap();
     let patch = HashMap::from([(crates_io_url, patches)]);
     let members = vec![

--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -392,7 +392,7 @@ pub enum E {
 fn main() {
     use updated_crate::E;
     let x = E::Variant1;
-    match x { // Error: `E::Variant2` not covered
+    match x { // Error: non-exhaustive patterns: `E::Variant2` not covered
         E::Variant1 => {}
     }
 }
@@ -702,7 +702,7 @@ impl Trait for Foo {}
 
 fn main() {
     let x = Foo;
-    x.foo(1); // Error: this function takes 0 arguments
+    x.foo(1); // Error: this method takes 0 arguments but 1 argument was supplied
 }
 ```
 

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -111,7 +111,13 @@ fn basic() {
         // Importantly, this should not say [UPDATING]
         // There have been multiple bugs where every build triggers and update.
         .with_stderr(
-            "[COMPILING] foo v0.0.1 [..]\n\
+            "[UPDATING] git repository `https://github.com/solana-labs/compiler-builtins`\n\
+             warning: Patch `compiler_builtins v0.1.88 (https://github.com/solana-labs/compiler-builtins?tag=solana-tools-v1.36#e6395414)` was not used in the crate graph.\n\
+             Check that the patched package version and available features are compatible\n\
+             with the dependency requirements. If the patch has a different version from\n\
+             what is locked in the Cargo.lock file, run `cargo update` to use the new\n\
+             version. This may also occur with an optional dependency that is not enabled.\n\
+             [COMPILING] foo v0.0.1 [..]\n\
              [FINISHED] dev [..]",
         )
         .run();


### PR DESCRIPTION
When -Z build-std is used, patch compiler-builtins so that our own fork is downloaded.

Needed for https://github.com/solana-labs/solana/pull/23465.
