### PR TITLE
nix: Add shell.nix for building cargo

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,5 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.mkShell {
+  buildInputs = with pkgs; [ llvmPackages.bintools cargo rustc openssl pkg-config ];
+  OPENSSL_STATIC = "1";
+}


### PR DESCRIPTION
#### Problem

More information at https://github.com/anza-xyz/platform-tools/pull/109, but cargo is currently built with a few shared libraries.

#### Summary of changes

Add a shell.nix file for creating a nix-shell environment.