### PR TITLE
[SOL] Update error message with new installation method

### DIFF
--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -649,9 +649,11 @@ pub fn create_bcx<'a, 'gctx>(
                 "rustc {rustc_version} is not supported by the following package{plural}:\n
                  This is the rustc version that ships with Solana tools and \
                  not your system's rustc version. Use `cargo install cargo-build-sbf` \
-                 to install a new version. The freshly updated cargo-build-sbf \
-                 may not be in use if the old Solana CLI installation directory has priority \
-                 on the PATH variable.\n",
+                 to install the latest version. Ensure that the new cargo-build-sbf is used \
+                 by placing the cargo install directory (typically `~/.cargo/bin`) before the \
+                 Solana CLI installation directory \
+                 (typically `~/.local/share/solana/install/active_release/bin`) \
+                 on the `PATH` variable.\n",
             );
             incompatible.sort_by_key(|(unit, _)| (unit.pkg.name(), unit.pkg.version()));
             for (unit, msrv) in incompatible {

--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -647,9 +647,11 @@ pub fn create_bcx<'a, 'gctx>(
             let plural = if incompatible.len() == 1 { "" } else { "s" };
             let mut message = format!(
                 "rustc {rustc_version} is not supported by the following package{plural}:\n
-                 Note that this is the rustc version that ships with Solana tools and \
-                 not your system's rustc version. Use `agave-install update` or head \
-                 over to https://docs.anza.xyz/cli/install to install a newer version.\n",
+                 This is the rustc version that ships with Solana tools and \
+                 not your system's rustc version. Use `cargo install cargo-build-sbf` \
+                 to install a new version. The freshly updated cargo-build-sbf \
+                 may not be in use if the old Solana CLI installation directory has priority \
+                 on the PATH variable.\n",
             );
             incompatible.sort_by_key(|(unit, _)| (unit.pkg.name(), unit.pkg.version()));
             for (unit, msrv) in incompatible {

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -3019,7 +3019,7 @@ To reuse those artifacts with a future compilation, set the environment variable
 Caused by:
   rustc [..] is not supported by the following package:
 
-                   This is the rustc version that ships with Solana tools and not your system's rustc version. Use `cargo install cargo-build-sbf` to install a new version. The freshly updated cargo-build-sbf may not be in use if the old Solana CLI installation directory has priority on the PATH variable.
+                   This is the rustc version that ships with Solana tools and not your system's rustc version. Use `cargo install cargo-build-sbf` to install the latest version. Ensure that the new cargo-build-sbf is used by placing the cargo install directory (typically `~/.cargo/bin`) before the Solana CLI installation directory (typically `~/.local/share/solana/install/active_release/bin`) on the `PATH` variable.
     some-package-from-the-distant-future@0.1.0 requires rustc 1.2345.0
 
 "#]])

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -3019,7 +3019,7 @@ To reuse those artifacts with a future compilation, set the environment variable
 Caused by:
   rustc [..] is not supported by the following package:
 
-                   Note that this is the rustc version that ships with Solana tools and not your system's rustc version. Use `agave-install update` or head over to https://docs.anza.xyz/cli/install to install a newer version.
+                   This is the rustc version that ships with Solana tools and not your system's rustc version. Use `cargo install cargo-build-sbf` to install a new version. The freshly updated cargo-build-sbf may not be in use if the old Solana CLI installation directory has priority on the PATH variable.
     some-package-from-the-distant-future@0.1.0 requires rustc 1.2345.0
 
 "#]])

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -112,7 +112,7 @@ fn lint_self_incompatible_with_rust_version() {
         .with_stderr_data(str![[r#"
 [ERROR] rustc [..] is not supported by the following package:
 
-                 Note that this is the rustc version that ships with Solana tools and not your system's rustc version. Use `agave-install update` or head over to https://docs.anza.xyz/cli/install to install a newer version.
+                 This is the rustc version that ships with Solana tools and not your system's rustc version. Use `cargo install cargo-build-sbf` to install a new version. The freshly updated cargo-build-sbf may not be in use if the old Solana CLI installation directory has priority on the PATH variable.
   foo@0.0.1 requires rustc 1.9876.0
 
 
@@ -173,7 +173,7 @@ fn lint_dep_incompatible_with_rust_version() {
 [DOWNLOADED] rustc_compatible v0.0.1 (registry `dummy-registry`)
 [ERROR] rustc [..] is not supported by the following packages:
 
-                 Note that this is the rustc version that ships with Solana tools and not your system's rustc version. Use `agave-install update` or head over to https://docs.anza.xyz/cli/install to install a newer version.
+                 This is the rustc version that ships with Solana tools and not your system's rustc version. Use `cargo install cargo-build-sbf` to install a new version. The freshly updated cargo-build-sbf may not be in use if the old Solana CLI installation directory has priority on the PATH variable.
   too_new_child@0.0.1 requires rustc 1.2345.0
   too_new_parent@0.0.1 requires rustc 1.2345.0
 Either upgrade rustc or select compatible dependency versions with

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -112,7 +112,7 @@ fn lint_self_incompatible_with_rust_version() {
         .with_stderr_data(str![[r#"
 [ERROR] rustc [..] is not supported by the following package:
 
-                 This is the rustc version that ships with Solana tools and not your system's rustc version. Use `cargo install cargo-build-sbf` to install a new version. The freshly updated cargo-build-sbf may not be in use if the old Solana CLI installation directory has priority on the PATH variable.
+                 This is the rustc version that ships with Solana tools and not your system's rustc version. Use `cargo install cargo-build-sbf` to install the latest version. Ensure that the new cargo-build-sbf is used by placing the cargo install directory (typically `~/.cargo/bin`) before the Solana CLI installation directory (typically `~/.local/share/solana/install/active_release/bin`) on the `PATH` variable.
   foo@0.0.1 requires rustc 1.9876.0
 
 
@@ -173,7 +173,7 @@ fn lint_dep_incompatible_with_rust_version() {
 [DOWNLOADED] rustc_compatible v0.0.1 (registry `dummy-registry`)
 [ERROR] rustc [..] is not supported by the following packages:
 
-                 This is the rustc version that ships with Solana tools and not your system's rustc version. Use `cargo install cargo-build-sbf` to install a new version. The freshly updated cargo-build-sbf may not be in use if the old Solana CLI installation directory has priority on the PATH variable.
+                 This is the rustc version that ships with Solana tools and not your system's rustc version. Use `cargo install cargo-build-sbf` to install the latest version. Ensure that the new cargo-build-sbf is used by placing the cargo install directory (typically `~/.cargo/bin`) before the Solana CLI installation directory (typically `~/.local/share/solana/install/active_release/bin`) on the `PATH` variable.
   too_new_child@0.0.1 requires rustc 1.2345.0
   too_new_parent@0.0.1 requires rustc 1.2345.0
 Either upgrade rustc or select compatible dependency versions with


### PR DESCRIPTION
Given the SBPFv3 rollout, we will update the error messages telling users to fetch cargo-build-sbf directly from crates.io to expedite the adoption of newer platform tools versions.
